### PR TITLE
Changed expression path to allow for shorter notation

### DIFF
--- a/example/app-services/README.md
+++ b/example/app-services/README.md
@@ -88,22 +88,22 @@ $ dacrane apply base base -a '{ prefix: dacrane }'
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ instances.base.modules.acr }}" }'
+  -a '{ tag: v1, acr: "${{ instances.base.acr }}" }'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ instances.api-v1.modules.api-local-image.modules.image }}" }'
+  -a '{ image: "${{ instances.api-v1.api-local-image.image }}" }'
 ```
 
 ```bash
 $ dacrane apply db-migration schema-v1-local -a '
 version: v1
-network: ${{ instances.local.modules.net.name }}
+network: ${{ instances.local.net.name }}
 mysql:
   username: root
   password: my-secret-pw
-  host: ${{ instances.local.modules.db.name }}
+  host: ${{ instances.local.db.name }}
   database: api
 '
 ```
@@ -133,10 +133,10 @@ api: ${{ instances.api-v1 }}
 $ dacrane apply db-migration schema-v1-dev -a '
 version: v1
 mysql:
-  username: ${{ instances.dev.modules.mysql.administrator_login }}@${{ instances.dev.modules.mysql.name }}
-  password: ${{ instances.dev.modules.mysql.administrator_login_password }}
-  host: ${{ instances.dev.modules.mysql.fqdn }}
-  database: ${{ instances.dev.modules.mysql-database.parameter.database }}
+  username: ${{ instances.dev.mysql.administrator_login }}@${{ instances.dev.mysql.name }}
+  password: ${{ instances.dev.mysql.administrator_login_password }}
+  host: ${{ instances.dev.mysql.fqdn }}
+  database: ${{ instances.dev.mysql-database.parameter.database }}
 '
 ```
 

--- a/example/app-services/README.md
+++ b/example/app-services/README.md
@@ -88,22 +88,22 @@ $ dacrane apply base base -a '{ prefix: dacrane }'
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ instances.base.acr }}" }'
+  -a '{ tag: v1, acr: "${{ base.acr }}" }'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ instances.api-v1.api-local-image.image }}" }'
+  -a '{ image: "${{ api-v1.api-local-image.image }}" }'
 ```
 
 ```bash
 $ dacrane apply db-migration schema-v1-local -a '
 version: v1
-network: ${{ instances.local.net.name }}
+network: ${{ local.net.name }}
 mysql:
   username: root
   password: my-secret-pw
-  host: ${{ instances.local.db.name }}
+  host: ${{ local.db.name }}
   database: api
 '
 ```
@@ -124,8 +124,8 @@ $ curl http://localhost:3000/users
 $ dacrane apply app-service dev -a '
 env: dev
 spec: low
-base: ${{ instances.base }}
-api: ${{ instances.api-v1 }}
+base: ${{ base }}
+api: ${{ api-v1 }}
 '
 ```
 
@@ -133,10 +133,10 @@ api: ${{ instances.api-v1 }}
 $ dacrane apply db-migration schema-v1-dev -a '
 version: v1
 mysql:
-  username: ${{ instances.dev.mysql.administrator_login }}@${{ instances.dev.mysql.name }}
-  password: ${{ instances.dev.mysql.administrator_login_password }}
-  host: ${{ instances.dev.mysql.fqdn }}
-  database: ${{ instances.dev.mysql-database.parameter.database }}
+  username: ${{ dev.mysql.administrator_login }}@${{ dev.mysql.name }}
+  password: ${{ dev.mysql.administrator_login_password }}
+  host: ${{ dev.mysql.fqdn }}
+  database: ${{ dev.mysql-database.parameter.database }}
 '
 ```
 

--- a/example/app-services/README.md
+++ b/example/app-services/README.md
@@ -83,28 +83,29 @@ $ dacrane destroy qs-as
 This section explains the more practical way to deploy.
 
 ```bash
-$ dacrane apply base base -a '{ prefix: dacrane }'
+$ dacrane apply base base -a prefix=dacrane
 ```
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ base.acr }}" }'
+  -a tag=v1 -a acr='${{ base.acr }}'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ api-v1.api-local-image.image }}" }'
+  -a image='${{ api-v1.api-local-image.build.image }}' \
+  -a tag='${{ api-v1.api-local-image.build.tag }}'
 ```
 
 ```bash
-$ dacrane apply db-migration schema-v1-local -a '
-version: v1
-network: ${{ local.net.name }}
-mysql:
-  username: root
-  password: my-secret-pw
-  host: ${{ local.db.name }}
-  database: api
+$ dacrane apply db-migration schema-v1-local \
+  -a version=v1 \
+  -a network='${{ local.net.name }}' \
+  -a mysql='
+username: root
+password: my-secret-pw
+host: ${{ local.db.name }}
+database: api
 '
 ```
 
@@ -121,22 +122,21 @@ $ curl http://localhost:3000/users
 ```
 
 ```bash
-$ dacrane apply app-service dev -a '
-env: dev
-spec: low
-base: ${{ base }}
-api: ${{ api-v1 }}
-'
+$ dacrane apply app-service dev \
+  -a env=dev \
+  -a spec=low \
+  -a base='${{ base }}' \
+  -a api='${{ api-v1 }}'
 ```
 
 ```bash
-$ dacrane apply db-migration schema-v1-dev -a '
-version: v1
-mysql:
-  username: ${{ dev.mysql.administrator_login }}@${{ dev.mysql.name }}
-  password: ${{ dev.mysql.administrator_login_password }}
-  host: ${{ dev.mysql.fqdn }}
-  database: ${{ dev.mysql-database.parameter.database }}
+$ dacrane apply db-migration schema-v1-dev \
+  -a version=v1 \
+  -a mysql='
+username: ${{ dev.mysql.administrator_login }}@${{ dev.mysql.name }}
+password: ${{ dev.mysql.administrator_login_password }}
+host: ${{ dev.mysql.fqdn }}
+database: ${{ dev.mysql-database.database }}
 '
 ```
 
@@ -153,25 +153,5 @@ $ curl https://dev-dacrane-sample-as.azurewebsites.net/users
 ```
 
 ```bash
-$ dacrane destroy schema-v1-dev
-```
-
-```bash
-$ dacrane destroy dev
-```
-
-```bash
-$ dacrane destroy schema-v1-local
-```
-
-```bash
-$ dacrane destroy local
-```
-
-```bash
-$ dacrane destroy api-v1
-```
-
-```bash
-$ dacrane destroy base
+$ dacrane destroy schema-v1-dev dev schema-v1-local local api-v1 base
 ```

--- a/example/app-services/dacrane.yaml
+++ b/example/app-services/dacrane.yaml
@@ -7,17 +7,17 @@ modules:
 - name: container
   module: local-docker
   argument:
-    image: ${{ modules.image.modules.api-local-image.modules.image }}
+    image: ${{ image.api-local-image.image }}
 - name: migrate
   module: db-migration
   argument:
     version: v1
-    network: ${{ modules.container.modules.net.name }}
+    network: ${{ container.net.name }}
     mysql:
       username: root
       password: my-secret-pw
       database: api
-      host: ${{ modules.container.modules.db.name }}
+      host: ${{ container.db.name }}
 ---
 name: quick-start-as
 modules:
@@ -29,23 +29,23 @@ modules:
   module: api-image
   argument:
     tag: latest
-    acr: ${{ modules.qs-base.modules.acr }}
+    acr: ${{ qs-base.acr }}
 - name: qs-app-service
   module: app-service
   argument:
     env: qs
     spec: low
-    base: ${{ modules.qs-base }}
-    api: ${{ modules.qs-api-image }}
+    base: ${{ qs-base }}
+    api: ${{ qs-api-image }}
 - name: qs-migration
   module: db-migration
   argument:
     version: v1
     mysql:
-      username: ${{ modules.qs-app-service.modules.mysql.administrator_login }}@${{ modules.qs-app-service.modules.mysql.name }}
-      password: ${{ modules.qs-app-service.modules.mysql.administrator_login_password }}
-      host: ${{ modules.qs-app-service.modules.mysql.fqdn }}
-      database: ${{ modules.qs-app-service.modules.mysql-database.parameter.database }}
+      username: ${{ qs-app-service.mysql.administrator_login }}@${{ qs-app-service.mysql.name }}
+      password: ${{ qs-app-service.mysql.administrator_login_password }}
+      host: ${{ qs-app-service.mysql.fqdn }}
+      database: ${{ qs-app-service.mysql-database.parameter.database }}
 ---
 name: local-docker
 parameter:
@@ -68,7 +68,7 @@ modules:
     name: db
     image: mysql
     tag: 8.2.0
-    network: ${{ modules.net.name }}
+    network: ${{ net.name }}
     env:
       - name: MYSQL_ROOT_PASSWORD
         value: &password my-secret-pw
@@ -85,14 +85,14 @@ modules:
   argument:
     name: api
     image: ${{ parameter.image.image }}
-    network: ${{ modules.net.name }}
+    network: ${{ net.name }}
     tag: ${{ parameter.image.tag }}
     port: 3000:3000
     env:
       - name: PORT
         value: "3000"
       - name: MYSQL_HOST
-        value: ${{ modules.db.name }}
+        value: ${{ db.name }}
       - name: MYSQL_USER
         value: root
       - name: MYSQL_PASSWORD
@@ -190,8 +190,8 @@ modules:
   if: ${{ parameter.acr != null }}
   module: docker/resource/remote-image
   argument:
-    image: ${{ modules.api-local-image.modules.image.image }}
-    tag: ${{ modules.api-local-image.modules.image.tag }}
+    image: ${{ api-local-image.image.image }}
+    tag: ${{ api-local-image.image.tag }}
     remote:
       url: ${{ parameter.acr.login_server }}
       user: ${{ parameter.acr.admin_username }}
@@ -219,7 +219,7 @@ modules:
       subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
     resource:
       name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-asp
-      resource_group_name: ${{ parameter.base.modules.rg.name }}
+      resource_group_name: ${{ parameter.base.rg.name }}
       location: "Japan East"
       kind: "Linux"
       reserved: true
@@ -232,7 +232,7 @@ modules:
     provider: *azurerm
     resource:
       name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-mysql
-      resource_group_name: ${{ parameter.base.modules.rg.name }}
+      resource_group_name: ${{ parameter.base.rg.name }}
       location: "Japan East"
       sku_name: "B_Gen5_2"
       version: "8.0"
@@ -246,8 +246,8 @@ modules:
     provider: *azurerm
     resource:
       name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-mysql-firewall-allow-all-ip-address
-      resource_group_name: ${{ parameter.base.modules.rg.name }}
-      server_name: ${{ modules.mysql.name }}
+      resource_group_name: ${{ parameter.base.rg.name }}
+      server_name: ${{ mysql.name }}
       start_ip_address: 0.0.0.0
       end_ip_address: 255.255.255.255
 - name: mysql-database
@@ -256,8 +256,8 @@ modules:
   argument:
     database: api
     mysql:
-      host: ${{ modules.mysql.fqdn }}
-      username: mysqladminun@${{ modules.mysql.name }}
+      host: ${{ mysql.fqdn }}
+      username: mysqladminun@${{ mysql.name }}
       password: ${{ env.MYSQL_PASSWORD }}
 - name: as
   module: terraform/resource/azurerm_app_service
@@ -265,19 +265,19 @@ modules:
     provider: *azurerm
     resource:
       name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-as
-      resource_group_name: ${{ parameter.base.modules.rg.name }}
+      resource_group_name: ${{ parameter.base.rg.name }}
       location: "Japan East"
-      app_service_plan_id: ${{ modules.asp.id }}
+      app_service_plan_id: ${{ asp.id }}
       site_config:
-        linux_fx_version: DOCKER|${{ parameter.base.modules.acr.login_server }}/sample-api:${{ parameter.api.modules.api-remote-image.tag }}
+        linux_fx_version: DOCKER|${{ parameter.base.acr.login_server }}/sample-api:${{ parameter.api.api-remote-image.tag }}
       app_settings:
-        DOCKER_REGISTRY_SERVER_URL: ${{ parameter.base.modules.acr.login_server }}
-        DOCKER_REGISTRY_SERVER_USERNAME: ${{ parameter.base.modules.acr.admin_username }}
-        DOCKER_REGISTRY_SERVER_PASSWORD: ${{ parameter.base.modules.acr.admin_password }}
+        DOCKER_REGISTRY_SERVER_URL: ${{ parameter.base.acr.login_server }}
+        DOCKER_REGISTRY_SERVER_USERNAME: ${{ parameter.base.acr.admin_username }}
+        DOCKER_REGISTRY_SERVER_PASSWORD: ${{ parameter.base.acr.admin_password }}
         WEBSITES_PORT: "3000"
-        MYSQL_HOST: ${{ modules.mysql.fqdn }}
+        MYSQL_HOST: ${{ mysql.fqdn }}
         MYSQL_DATABASE: api
-        MYSQL_USER: mysqladminun@${{ modules.mysql.name }}
+        MYSQL_USER: mysqladminun@${{ mysql.name }}
         MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
 ---
 name: base
@@ -305,7 +305,7 @@ modules:
     provider: *azurerm
     resource:
       name: ${{ parameter.prefix }}sampleacr
-      resource_group_name: ${{ modules.rg.name }}
+      resource_group_name: ${{ rg.name }}
       location: "Japan East"
       sku: Basic
       admin_enabled: true

--- a/example/app-services/dacrane.yaml
+++ b/example/app-services/dacrane.yaml
@@ -2,15 +2,16 @@ name: quick-start
 modules:
 - name: image
   module: api-image
-  argument:
+  arguments:
     tag: latest
 - name: container
   module: local-docker
-  argument:
-    image: ${{ image.api-local-image.image }}
+  arguments:
+    image: ${{ image.api-local-image.build.image }}
+    tag: ${{ image.api-local-image.build.tag }}
 - name: migrate
   module: db-migration
-  argument:
+  arguments:
     version: v1
     network: ${{ container.net.name }}
     mysql:
@@ -23,48 +24,44 @@ name: quick-start-as
 modules:
 - name: qs-base
   module: base
-  argument:
+  arguments:
     prefix: dacrane
 - name: qs-api-image
   module: api-image
-  argument:
+  arguments:
     tag: latest
     acr: ${{ qs-base.acr }}
 - name: qs-app-service
   module: app-service
-  argument:
+  arguments:
     env: qs
     spec: low
     base: ${{ qs-base }}
     api: ${{ qs-api-image }}
 - name: qs-migration
   module: db-migration
-  argument:
+  arguments:
     version: v1
     mysql:
       username: ${{ qs-app-service.mysql.administrator_login }}@${{ qs-app-service.mysql.name }}
       password: ${{ qs-app-service.mysql.administrator_login_password }}
       host: ${{ qs-app-service.mysql.fqdn }}
-      database: ${{ qs-app-service.mysql-database.parameter.database }}
+      database: ${{ qs-app-service.mysql-database.database }}
 ---
 name: local-docker
-parameter:
-  type: object
-  default: { image: sample-api, tag: latest }
-  properties:
-    image:
-      type: object
-      properties:
-        image: { type: string, default: sample-api }
-        tag: { type: string, default: latest }
+parameters:
+- name: image
+  schema: { type: string, default: sample-api }
+- name: tag
+  schema: { type: string, default: latest }
 modules:
 - module: docker/resource/network
   name: net
-  argument:
+  arguments:
     name: api-net
 - module: docker/resource/container
   name: db
-  argument:
+  arguments:
     name: db
     image: mysql
     tag: 8.2.0
@@ -82,11 +79,11 @@ modules:
       start_period: 30s
 - module: docker/resource/container
   name: api
-  argument:
+  arguments:
     name: api
-    image: ${{ parameter.image.image }}
+    image: ${{ image }}
     network: ${{ net.name }}
-    tag: ${{ parameter.image.tag }}
+    tag: ${{ tag }}
     port: 3000:3000
     env:
       - name: PORT
@@ -101,116 +98,117 @@ modules:
         value: *database
 ---
 name: db-migration
-parameter:
-  type: object
-  required: ["version"]
-  properties:
-    version: { type: string }
-    network: { type: string }
-    mysql:
-      type: object
-      required: ["username", "password", "host"]
-      properties:
-        username: { type: string }
-        password: { type: string }
-        database: { type: string }
-        host: { type: string }
+parameters:
+- name: version
+  schema: { type: string }
+- name: network
+  schema: { type: ["string", "null"] }
+- name: mysql
+  schema:
+    type: object
+    required: ["username", "password", "host"]
+    properties:
+      username: { type: string }
+      password: { type: string }
+      database: { type: string }
+      host: { type: string }
 modules:
 - name: migrate
   module: custom/resource/shell
-  argument:
+  arguments:
     image: mysql
     tag: 8.2.0
-    network: ${{ parameter.network }}
+    network: ${{ network }}
     env: []
     shell: /bin/bash
     create:
       mysql
-      -h ${{ parameter.mysql.host }}
-      -u ${{ parameter.mysql.username }}
-      -p${{ parameter.mysql.password }}
-      ${{ parameter.mysql.database }}
-      < /work/schemas/${{ parameter.version }}-up.sql
+      -h ${{ mysql.host }}
+      -u ${{ mysql.username }}
+      -p${{ mysql.password }}
+      ${{ mysql.database }}
+      < /work/schemas/${{ version }}-up.sql
     delete:
       mysql
-      -h ${{ parameter.mysql.host }}
-      -u ${{ parameter.mysql.username }}
-      -p${{ parameter.mysql.password }}
-      ${{ parameter.mysql.database }}
-      < /work/schemas/${{ parameter.version }}-down.sql
+      -h ${{ mysql.host }}
+      -u ${{ mysql.username }}
+      -p${{ mysql.password }}
+      ${{ mysql.database }}
+      < /work/schemas/${{ version }}-down.sql
 ---
 name: mysql-database
-parameter:
-  type: object
-  properties:
-    database: { type: string }
-    mysql:
-      type: object
-      required: ["username", "password", "host"]
-      properties:
-        username: { type: string }
-        password: { type: string }
-        host: { type: string }
+parameters:
+- name: database
+  schema: { type: string }
+- name: mysql
+  schema:
+    type: object
+    required: ["username", "password", "host"]
+    properties:
+      username: { type: string }
+      password: { type: string }
+      host: { type: string }
 modules:
 - name: mysql-database
   module: custom/resource/shell
-  argument:
+  arguments:
     image: mysql
     tag: 8.2.0
-    network: ${{ parameter.network }}
+    network: ${{ network }}
     env: []
     shell: /bin/bash
     create:
-      echo 'CREATE DATABASE IF NOT EXISTS ${{ parameter.database }};' | mysql
-      -h ${{ parameter.mysql.host }}
-      -u ${{ parameter.mysql.username }}
-      -p${{ parameter.mysql.password }}
+      echo 'CREATE DATABASE IF NOT EXISTS ${{ database }};' | mysql
+      -h ${{ mysql.host }}
+      -u ${{ mysql.username }}
+      -p${{ mysql.password }}
     delete:
-      echo 'DROP DATABASE IF EXISTS ${{ parameter.database }};' | mysql
-      -h ${{ parameter.mysql.host }}
-      -u ${{ parameter.mysql.username }}
-      -p${{ parameter.mysql.password }}
+      echo 'DROP DATABASE IF EXISTS ${{ database }};' | mysql
+      -h ${{ mysql.host }}
+      -u ${{ mysql.username }}
+      -p${{ mysql.password }}
 ---
 name: api-image
-parameter:
-  type: object
-  properties:
-    tag: { type: string, default: "latest" }
-    acr: { type: object }
+parameters:
+- name: tag
+  schema: { type: string, default: "latest" }
+- name: acr
+  schema: { type: ["object", "null"] }
 import:
   - ../../module/docker-npm.yaml
   # - import: https://raw.githubusercontent.com/SIOS-Technology-Inc/dacrane/main/module/docker-npm.yaml
 modules:
 - name: api-local-image
   module: docker-npm
-  argument:
+  arguments:
     image: sample-api
-    tag: ${{ parameter.tag }}
+    tag: ${{ tag }}
 - name: api-remote-image
-  if: ${{ parameter.acr != null }}
+  if: ${{ acr != null }}
   module: docker/resource/remote-image
-  argument:
-    image: ${{ api-local-image.image.image }}
-    tag: ${{ api-local-image.image.tag }}
+  arguments:
+    image: ${{ api-local-image.build.image }}
+    tag: ${{ api-local-image.build.tag }}
     remote:
-      url: ${{ parameter.acr.login_server }}
-      user: ${{ parameter.acr.admin_username }}
-      password: ${{ parameter.acr.admin_password }}
+      url: ${{ acr.login_server }}
+      user: ${{ acr.admin_username }}
+      password: ${{ acr.admin_password }}
 ---
 name: app-service
-argument:
-parameter:
-  type: object
-  required: ["env", "base", "api"]
-  properties:
-    env: { type: string, default: "dev" }
-    spec: { type: string, enum: ["low", "high"], default: "low" }
-    base: { type: object }
-    api: { type: object }
+arguments:
+parameters:
+- name: env
+  schema: { type: string, default: "dev" }
+- name: spec
+  schema: { type: string, enum: ["low", "high"], default: "low" }
+- name: base
+  schema: { type: object }
+- name: api
+  schema: { type: object }
 modules:
 - name: asp
   module: terraform/resource/azurerm_app_service_plan
-  argument:
+  arguments:
     provider: &azurerm
       features: {}
       client_id: ${{ $env.ARM_CLIENT_ID }}
@@ -218,21 +216,21 @@ modules:
       tenant_id: ${{ $env.ARM_TENANT_ID }}
       subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
     resource:
-      name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-asp
-      resource_group_name: ${{ parameter.base.rg.name }}
+      name: ${{ env }}-${{ base.prefix }}-sample-asp
+      resource_group_name: ${{ base.rg.name }}
       location: "Japan East"
       kind: "Linux"
       reserved: true
       sku:
-        tier: '${{ {"low": "Basic", "high": "Standard" }[parameter.spec] }}'
-        size: '${{ {"low": "B1", "high": "S1" }[parameter.spec] }}'
+        tier: '${{ {"low": "Basic", "high": "Standard" }[spec] }}'
+        size: '${{ {"low": "B1", "high": "S1" }[spec] }}'
 - name: mysql
   module: terraform/resource/azurerm_mysql_server
-  argument:
+  arguments:
     provider: *azurerm
     resource:
-      name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-mysql
-      resource_group_name: ${{ parameter.base.rg.name }}
+      name: ${{ env }}-${{ base.prefix }}-sample-mysql
+      resource_group_name: ${{ base.rg.name }}
       location: "Japan East"
       sku_name: "B_Gen5_2"
       version: "8.0"
@@ -242,18 +240,18 @@ modules:
       ssl_minimal_tls_version_enforced: TLSEnforcementDisabled
 - name: mysql-firewall-role
   module: terraform/resource/azurerm_mysql_firewall_rule
-  argument:
+  arguments:
     provider: *azurerm
     resource:
-      name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-mysql-firewall-allow-all-ip-address
-      resource_group_name: ${{ parameter.base.rg.name }}
+      name: ${{ env }}-${{ base.prefix }}-sample-mysql-firewall-allow-all-ip-address
+      resource_group_name: ${{ base.rg.name }}
       server_name: ${{ mysql.name }}
       start_ip_address: 0.0.0.0
       end_ip_address: 255.255.255.255
 - name: mysql-database
   module: mysql-database
   depends_on: [mysql-firewall-role]
-  argument:
+  arguments:
     database: api
     mysql:
       host: ${{ mysql.fqdn }}
@@ -261,19 +259,19 @@ modules:
       password: ${{ $env.MYSQL_PASSWORD }}
 - name: as
   module: terraform/resource/azurerm_app_service
-  argument:
+  arguments:
     provider: *azurerm
     resource:
-      name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-as
-      resource_group_name: ${{ parameter.base.rg.name }}
+      name: ${{ env }}-${{ base.prefix }}-sample-as
+      resource_group_name: ${{ base.rg.name }}
       location: "Japan East"
       app_service_plan_id: ${{ asp.id }}
       site_config:
-        linux_fx_version: DOCKER|${{ parameter.base.acr.login_server }}/sample-api:${{ parameter.api.api-remote-image.tag }}
+        linux_fx_version: DOCKER|${{ base.acr.login_server }}/sample-api:${{ api.api-remote-image.tag }}
       app_settings:
-        DOCKER_REGISTRY_SERVER_URL: ${{ parameter.base.acr.login_server }}
-        DOCKER_REGISTRY_SERVER_USERNAME: ${{ parameter.base.acr.admin_username }}
-        DOCKER_REGISTRY_SERVER_PASSWORD: ${{ parameter.base.acr.admin_password }}
+        DOCKER_REGISTRY_SERVER_URL: ${{ base.acr.login_server }}
+        DOCKER_REGISTRY_SERVER_USERNAME: ${{ base.acr.admin_username }}
+        DOCKER_REGISTRY_SERVER_PASSWORD: ${{ base.acr.admin_password }}
         WEBSITES_PORT: "3000"
         MYSQL_HOST: ${{ mysql.fqdn }}
         MYSQL_DATABASE: api
@@ -281,15 +279,13 @@ modules:
         MYSQL_PASSWORD: ${{ $env.MYSQL_PASSWORD }}
 ---
 name: base
-parameter:
-  type: object
-  required: ["prefix"]
-  properties:
-    prefix: { type: string }
+parameters:
+- name: prefix
+  schema: { type: string }
 modules:
 - name: rg
   module: terraform/resource/azurerm_resource_group
-  argument:
+  arguments:
     provider: &azurerm
       features: {}
       client_id: ${{ $env.ARM_CLIENT_ID }}
@@ -297,14 +293,14 @@ modules:
       tenant_id: ${{ $env.ARM_TENANT_ID }}
       subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
     resource:
-      name: ${{ parameter.prefix }}-sample-rg
+      name: ${{ prefix }}-sample-rg
       location: "Japan East"
 - name: acr
   module: terraform/resource/azurerm_container_registry
-  argument:
+  arguments:
     provider: *azurerm
     resource:
-      name: ${{ parameter.prefix }}sampleacr
+      name: ${{ prefix }}sampleacr
       resource_group_name: ${{ rg.name }}
       location: "Japan East"
       sku: Basic

--- a/example/app-services/dacrane.yaml
+++ b/example/app-services/dacrane.yaml
@@ -213,10 +213,10 @@ modules:
   argument:
     provider: &azurerm
       features: {}
-      client_id: ${{ env.ARM_CLIENT_ID }}
-      client_secret: ${{ env.ARM_CLIENT_SECRET }}
-      tenant_id: ${{ env.ARM_TENANT_ID }}
-      subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+      client_id: ${{ $env.ARM_CLIENT_ID }}
+      client_secret: ${{ $env.ARM_CLIENT_SECRET }}
+      tenant_id: ${{ $env.ARM_TENANT_ID }}
+      subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
     resource:
       name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-asp
       resource_group_name: ${{ parameter.base.rg.name }}
@@ -237,7 +237,7 @@ modules:
       sku_name: "B_Gen5_2"
       version: "8.0"
       administrator_login: mysqladminun
-      administrator_login_password: ${{ env.MYSQL_PASSWORD }}
+      administrator_login_password: ${{ $env.MYSQL_PASSWORD }}
       ssl_enforcement_enabled: false
       ssl_minimal_tls_version_enforced: TLSEnforcementDisabled
 - name: mysql-firewall-role
@@ -278,7 +278,7 @@ modules:
         MYSQL_HOST: ${{ mysql.fqdn }}
         MYSQL_DATABASE: api
         MYSQL_USER: mysqladminun@${{ mysql.name }}
-        MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        MYSQL_PASSWORD: ${{ $env.MYSQL_PASSWORD }}
 ---
 name: base
 parameter:
@@ -292,10 +292,10 @@ modules:
   argument:
     provider: &azurerm
       features: {}
-      client_id: ${{ env.ARM_CLIENT_ID }}
-      client_secret: ${{ env.ARM_CLIENT_SECRET }}
-      tenant_id: ${{ env.ARM_TENANT_ID }}
-      subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+      client_id: ${{ $env.ARM_CLIENT_ID }}
+      client_secret: ${{ $env.ARM_CLIENT_SECRET }}
+      tenant_id: ${{ $env.ARM_TENANT_ID }}
+      subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
     resource:
       name: ${{ parameter.prefix }}-sample-rg
       location: "Japan East"

--- a/example/app-services/dacrane.yaml
+++ b/example/app-services/dacrane.yaml
@@ -258,7 +258,7 @@ modules:
     mysql:
       host: ${{ mysql.fqdn }}
       username: mysqladminun@${{ mysql.name }}
-      password: ${{ env.MYSQL_PASSWORD }}
+      password: ${{ $env.MYSQL_PASSWORD }}
 - name: as
   module: terraform/resource/azurerm_app_service
   argument:

--- a/example/azure-kube-service/README.md
+++ b/example/azure-kube-service/README.md
@@ -65,17 +65,18 @@ $ dacrane destroy qs-aks
 This section explains the more practical way to deploy.
 
 ```bash
-$ dacrane apply base base -a '{ prefix: dacrane }'
+$ dacrane apply base base -a prefix=dacrane
 ```
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ base.acr }}" }'
+  -a tag=v1 -a acr='${{ base.acr }}'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ api-v1.api-local-image.image }}" }'
+  -a image='${{ api-v1.api-local-image.build.image }}' \
+  -a tag='${{ api-v1.api-local-image.build.tag }}'
 ```
 
 ```bash
@@ -85,11 +86,10 @@ hello world
 ```
 
 ```bash
-$ dacrane apply aks dev -a '
-env: dev
-base: ${{ base }}
-api: ${{ api-v1 }}
-'
+$ dacrane apply aks dev \
+  -a env=dev \
+  -a base='${{ base }}' \
+  -a api='${{ api-v1 }}'
 ```
 
 ```bash
@@ -99,17 +99,5 @@ hello world
 ```
 
 ```bash
-$ dacrane destroy dev
-```
-
-```bash
-$ dacrane destroy local
-```
-
-```bash
-$ dacrane destroy api-v1
-```
-
-```bash
-$ dacrane destroy base
+$ dacrane destroy dev local api-v1 base
 ```

--- a/example/azure-kube-service/README.md
+++ b/example/azure-kube-service/README.md
@@ -70,12 +70,12 @@ $ dacrane apply base base -a '{ prefix: dacrane }'
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ instances.base.acr }}" }'
+  -a '{ tag: v1, acr: "${{ base.acr }}" }'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ instances.api-v1.api-local-image.image }}" }'
+  -a '{ image: "${{ api-v1.api-local-image.image }}" }'
 ```
 
 ```bash
@@ -87,8 +87,8 @@ hello world
 ```bash
 $ dacrane apply aks dev -a '
 env: dev
-base: ${{ instances.base }}
-api: ${{ instances.api-v1 }}
+base: ${{ base }}
+api: ${{ api-v1 }}
 '
 ```
 

--- a/example/azure-kube-service/README.md
+++ b/example/azure-kube-service/README.md
@@ -70,12 +70,12 @@ $ dacrane apply base base -a '{ prefix: dacrane }'
 
 ```bash
 $ dacrane apply api-image api-v1 \
-  -a '{ tag: v1, acr: "${{ instances.base.modules.acr }}" }'
+  -a '{ tag: v1, acr: "${{ instances.base.acr }}" }'
 ```
 
 ```bash
 $ dacrane apply local-docker local \
-  -a '{ image: "${{ instances.api-v1.modules.api-local-image.modules.image }}" }'
+  -a '{ image: "${{ instances.api-v1.api-local-image.image }}" }'
 ```
 
 ```bash

--- a/example/azure-kube-service/dacrane.yaml
+++ b/example/azure-kube-service/dacrane.yaml
@@ -91,10 +91,10 @@ modules:
     argument:
       provider: &azurerm
         features: {}
-        client_id: ${{ env.ARM_CLIENT_ID }}
-        client_secret: ${{ env.ARM_CLIENT_SECRET }}
-        tenant_id: ${{ env.ARM_TENANT_ID }}
-        subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+        client_id: ${{ $env.ARM_CLIENT_ID }}
+        client_secret: ${{ $env.ARM_CLIENT_SECRET }}
+        tenant_id: ${{ $env.ARM_TENANT_ID }}
+        subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
       resource:
         name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-aks
         location: "Japan East"
@@ -173,10 +173,10 @@ modules:
     argument:
       provider: &azurerm
         features: {}
-        client_id: ${{ env.ARM_CLIENT_ID }}
-        client_secret: ${{ env.ARM_CLIENT_SECRET }}
-        tenant_id: ${{ env.ARM_TENANT_ID }}
-        subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+        client_id: ${{ $env.ARM_CLIENT_ID }}
+        client_secret: ${{ $env.ARM_CLIENT_SECRET }}
+        tenant_id: ${{ $env.ARM_TENANT_ID }}
+        subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
       resource:
         name: ${{ parameter.prefix }}-sample-rg
         location: "Japan East"

--- a/example/azure-kube-service/dacrane.yaml
+++ b/example/azure-kube-service/dacrane.yaml
@@ -7,7 +7,7 @@ modules:
   - name: container
     module: local-docker
     argument:
-      image: ${{ modules.image.modules.api-local-image.modules.image }}
+      image: ${{ image.api-local-image.image }}
 ---
 name: quick-start-aks
 modules:
@@ -19,14 +19,14 @@ modules:
     module: api-image
     argument:
       tag: latest
-      acr: ${{ modules.qs-base.modules.acr }}
+      acr: ${{ qs-base.acr }}
   - name: qs-aks
     module: aks
     argument:
       env: qs
       spec: low
-      base: ${{ modules.qs-base }}
-      api: ${{ modules.qs-api-image }}
+      base: ${{ qs-base }}
+      api: ${{ qs-api-image }}
 ---
 name: local-docker
 parameter:
@@ -69,8 +69,8 @@ modules:
     if: ${{ parameter.acr != null }}
     module: docker/resource/remote-image
     argument:
-      image: ${{ modules.api-local-image.modules.image.image }}
-      tag: ${{ modules.api-local-image.modules.image.tag }}
+      image: ${{ api-local-image.image.image }}
+      tag: ${{ api-local-image.image.tag }}
       remote:
         url: ${{ parameter.acr.login_server }}
         user: ${{ parameter.acr.admin_username }}
@@ -98,7 +98,7 @@ modules:
       resource:
         name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-aks
         location: "Japan East"
-        resource_group_name: ${{ parameter.base.modules.rg.name }}
+        resource_group_name: ${{ parameter.base.rg.name }}
         dns_prefix: exampleaks1
         default_node_pool:
           name: default
@@ -111,19 +111,19 @@ modules:
     argument:
       provider: *azurerm
       resource:
-        principal_id: ${{ modules.aks-cluster.kubelet_identity[0].object_id }}
+        principal_id: ${{ aks-cluster.kubelet_identity[0].object_id }}
         role_definition_name: "AcrPull"
-        scope: ${{ parameter.base.modules.acr.id }}
+        scope: ${{ parameter.base.acr.id }}
         skip_service_principal_aad_check: true
   - name: aks-development
     module: terraform/resource/kubernetes_deployment_v1
     depends_on: [role-assignment]
     argument:
       provider: &kubernetes
-        host: ${{ modules.aks-cluster.kube_config[0].host }}
-        client_certificate: ${base64decode("${{ modules.aks-cluster.kube_config[0].client_certificate }}")}
-        client_key: ${base64decode("${{ modules.aks-cluster.kube_config[0].client_key }}")}
-        cluster_ca_certificate: ${base64decode("${{ modules.aks-cluster.kube_config[0].cluster_ca_certificate }}")}
+        host: ${{ aks-cluster.kube_config[0].host }}
+        client_certificate: ${base64decode("${{ aks-cluster.kube_config[0].client_certificate }}")}
+        client_key: ${base64decode("${{ aks-cluster.kube_config[0].client_key }}")}
+        cluster_ca_certificate: ${base64decode("${{ aks-cluster.kube_config[0].cluster_ca_certificate }}")}
       resource:
         metadata:
           name: sample-api
@@ -139,7 +139,7 @@ modules:
             spec:
               container:
                 - name: sample-api
-                  image: ${{ parameter.base.modules.acr.login_server }}/sample-api:${{ parameter.api.modules.api-remote-image.tag }}
+                  image: ${{ parameter.base.acr.login_server }}/sample-api:${{ parameter.api.api-remote-image.tag }}
                   port:
                     - container_port: 3000
   - name: aks-service
@@ -186,7 +186,7 @@ modules:
       provider: *azurerm
       resource:
         name: ${{ parameter.prefix }}sampleacr
-        resource_group_name: ${{ modules.rg.name }}
+        resource_group_name: ${{ rg.name }}
         location: "Japan East"
         sku: Basic
         admin_enabled: true

--- a/example/azure-kube-service/dacrane.yaml
+++ b/example/azure-kube-service/dacrane.yaml
@@ -2,93 +2,90 @@ name: quick-start
 modules:
   - name: image
     module: api-image
-    argument:
+    arguments:
       tag: latest
   - name: container
     module: local-docker
-    argument:
-      image: ${{ image.api-local-image.image }}
+    arguments:
+      image: ${{ image.api-local-image.build.image }}
+      tag: ${{ image.api-local-image.build.tag }}
 ---
 name: quick-start-aks
 modules:
   - name: qs-base
     module: base
-    argument:
+    arguments:
       prefix: dacrane
   - name: qs-api-image
     module: api-image
-    argument:
+    arguments:
       tag: latest
       acr: ${{ qs-base.acr }}
   - name: qs-aks
     module: aks
-    argument:
+    arguments:
       env: qs
       spec: low
       base: ${{ qs-base }}
       api: ${{ qs-api-image }}
 ---
 name: local-docker
-parameter:
-  type: object
-  default: { image: sample-api, tag: latest }
-  properties:
-    image:
-      type: object
-      properties:
-        image: { type: string, default: sample-api }
-        tag: { type: string, default: latest }
+parameters:
+- name: image
+  schema: { type: string, default: sample-api }
+- name: tag
+  schema: { type: string, default: latest }
 modules:
   - module: docker/resource/container
     name: docker
-    argument:
+    arguments:
       name: api
-      image: ${{ parameter.image.image }}
-      tag: ${{ parameter.image.tag }}
+      image: ${{ image }}
+      tag: ${{ tag }}
       port: 3000:3000
       env:
         - name: PORT
           value: "3000"
 ---
 name: api-image
-parameter:
-  type: object
-  properties:
-    tag: { type: string, default: "latest" }
-    acr: { type: object }
+parameters:
+- name: tag
+  schema: { type: string, default: "latest" }
+- name: acr
+  schema: { type: ["object", "null"] }
 import:
   - ../../module/docker-npm.yaml
   # - import: https://raw.githubusercontent.com/SIOS-Technology-Inc/dacrane/main/module/docker-npm.yaml
 modules:
   - name: api-local-image
     module: docker-npm
-    argument:
+    arguments:
       image: sample-api
-      tag: ${{ parameter.tag }}
+      tag: ${{ tag }}
   - name: api-remote-image
-    if: ${{ parameter.acr != null }}
+    if: ${{ acr != null }}
     module: docker/resource/remote-image
-    argument:
-      image: ${{ api-local-image.image.image }}
-      tag: ${{ api-local-image.image.tag }}
+    arguments:
+      image: ${{ api-local-image.build.image }}
+      tag: ${{ api-local-image.build.tag }}
       remote:
-        url: ${{ parameter.acr.login_server }}
-        user: ${{ parameter.acr.admin_username }}
-        password: ${{ parameter.acr.admin_password }}
+        url: ${{ acr.login_server }}
+        user: ${{ acr.admin_username }}
+        password: ${{ acr.admin_password }}
 ---
 name: aks
-argument:
-parameter:
-  type: object
-  required: ["base"]
-  properties:
-    env: { type: string, default: "dev" }
-    base: { type: object }
-    api: { type: object }
+arguments:
+parameters:
+- name: env
+  schema: { type: string, default: "dev" }
+- name: base
+  schema: { type: object }
+- name: api
+  schema: { type: object }
 modules:
   - name: aks-cluster
     module: terraform/resource/azurerm_kubernetes_cluster
-    argument:
+    arguments:
       provider: &azurerm
         features: {}
         client_id: ${{ $env.ARM_CLIENT_ID }}
@@ -96,9 +93,9 @@ modules:
         tenant_id: ${{ $env.ARM_TENANT_ID }}
         subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
       resource:
-        name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}-sample-aks
+        name: ${{ env }}-${{ base.prefix }}-sample-aks
         location: "Japan East"
-        resource_group_name: ${{ parameter.base.rg.name }}
+        resource_group_name: ${{ base.rg.name }}
         dns_prefix: exampleaks1
         default_node_pool:
           name: default
@@ -108,17 +105,17 @@ modules:
           type: SystemAssigned
   - name: role-assignment
     module: terraform/resource/azurerm_role_assignment
-    argument:
+    arguments:
       provider: *azurerm
       resource:
         principal_id: ${{ aks-cluster.kubelet_identity[0].object_id }}
         role_definition_name: "AcrPull"
-        scope: ${{ parameter.base.acr.id }}
+        scope: ${{ base.acr.id }}
         skip_service_principal_aad_check: true
   - name: aks-development
     module: terraform/resource/kubernetes_deployment_v1
     depends_on: [role-assignment]
-    argument:
+    arguments:
       provider: &kubernetes
         host: ${{ aks-cluster.kube_config[0].host }}
         client_certificate: ${base64decode("${{ aks-cluster.kube_config[0].client_certificate }}")}
@@ -139,18 +136,18 @@ modules:
             spec:
               container:
                 - name: sample-api
-                  image: ${{ parameter.base.acr.login_server }}/sample-api:${{ parameter.api.api-remote-image.tag }}
+                  image: ${{ base.acr.login_server }}/sample-api:${{ api.api-remote-image.tag }}
                   port:
                     - container_port: 3000
   - name: aks-service
     module: terraform/resource/kubernetes_service_v1
-    argument:
+    arguments:
       provider: *kubernetes
       resource:
         metadata:
           name: public-svc
           annotations:
-            service.beta.kubernetes.io/azure-dns-label-name: ${{ parameter.env }}-${{ parameter.base.parameter.prefix }}
+            service.beta.kubernetes.io/azure-dns-label-name: ${{ env }}-${{ base.prefix }}
         spec:
           type: LoadBalancer
           port:
@@ -162,15 +159,13 @@ modules:
         wait_for_load_balancer: true
 ---
 name: base
-parameter:
-  type: object
-  required: ["prefix"]
-  properties:
-    prefix: { type: string }
+parameters:
+- name: prefix
+  schema: { type: string }
 modules:
   - name: rg
     module: terraform/resource/azurerm_resource_group
-    argument:
+    arguments:
       provider: &azurerm
         features: {}
         client_id: ${{ $env.ARM_CLIENT_ID }}
@@ -178,14 +173,14 @@ modules:
         tenant_id: ${{ $env.ARM_TENANT_ID }}
         subscription_id: ${{ $env.ARM_SUBSCRIPTION_ID }}
       resource:
-        name: ${{ parameter.prefix }}-sample-rg
+        name: ${{ prefix }}-sample-rg
         location: "Japan East"
   - name: acr
     module: terraform/resource/azurerm_container_registry
-    argument:
+    arguments:
       provider: *azurerm
       resource:
-        name: ${{ parameter.prefix }}sampleacr
+        name: ${{ prefix }}sampleacr
         resource_group_name: ${{ rg.name }}
         location: "Japan East"
         sku: Basic

--- a/module/docker-npm.yaml
+++ b/module/docker-npm.yaml
@@ -64,6 +64,6 @@ modules:
 - name: image
   module: docker/resource/local-image
   argument:
-    dockerfile: ${{ modules.dockerfile.filename }}
+    dockerfile: ${{ dockerfile.filename }}
     image: ${{ parameter.image }}
     tag: ${{ parameter.tag }}

--- a/module/docker-npm.yaml
+++ b/module/docker-npm.yaml
@@ -1,69 +1,74 @@
 name: docker-npm
-parameter:
-  type: object
-  required: ["image"]
-  properties:
+parameters:
     # TODO Add full docker build options.
-    node_base_image_tag:
-      title: Docker Image Tag
-      description: >
-        This is docker image tag name. https://hub.docker.com/_/node/
-      type: string
-      default: latest
-    src_files:
-      title: Source Code File Path
-      description: Source code file path
-      type: string
-      # TODO  Fix copy glob expression recursively.
-      default: "*.js"
-    package_json:
-      title: package.json File Path
-      description: package.json File Path
-      type: string
-      default: "./package.json"
-    package_json_lock:
-      title: package-lock.json File Path
-      description: package-lock.json File Path
-      type: string
-      default: "./package-lock.json"
-    build_command:
-      title: Build Command
-      description: This command is used to install or transpile dependent modules.
-      type: string
-      default: npm ci
-    start_command:
-      title: Start Command
-      description: This command is used to start the Node.js program.
-      type: string
-      default: npm start
-    image:
-      title: Image Name
-      description: The name of the image to be built.
-      type: string
-    tag:
-      title: Image Tag
-      description: The tag of the image to be built.
-      type: string
-      default: latest
+- name: node_base_image_tag
+  schema:
+    title: Docker Image Tag
+    description: >
+      This is docker image tag name. https://hub.docker.com/_/node/
+    type: ["string", "null"]
+    default: latest
+- name: src_files
+  schema:
+    title: Source Code File Path
+    description: Source code file path
+    type: ["string", "null"]
+    # TODO  Fix copy glob expression recursively.
+    default: "*.js"
+- name: package_json
+  schema:
+    title: package.json File Path
+    description: package.json File Path
+    type: ["string", "null"]
+    default: "./package.json"
+- name: package_json_lock
+  schema:
+    title: package-lock.json File Path
+    description: package-lock.json File Path
+    type: ["string", "null"]
+    default: "./package-lock.json"
+- name: build_command
+  schema:
+    title: Build Command
+    description: This command is used to install or transpile dependent modules.
+    type: ["string", "null"]
+    default: npm ci
+- name: start_command
+  schema:
+    title: Start Command
+    description: This command is used to start the Node.js program.
+    type: ["string", "null"]
+    default: npm start
+- name: image
+  schema:
+    title: Image Name
+    description: The name of the image to be built.
+    type: string
+- name: tag
+  schema:
+    title: Image Tag
+    description: The tag of the image to be built.
+    type: ["string", "null"]
+    default: latest
 modules:
 - name: dockerfile
   module: local/resource/file
-  argument:
-    filename: ${{ self.custom_state_path }}/Dockerfile
+  arguments:
+    filename: ${{ $self.custom_state_path }}/Dockerfile
     contents: |-
       # auto generated from dacrane
-      FROM node:${{ parameter.node_base_image_tag }}
+      FROM node:${{ node_base_image_tag }}
 
-      COPY ${{ parameter.src_files }} ./
-      COPY ${{ parameter.package_json }} ./package.json
-      COPY ${{ parameter.package_json_lock }} ./package-lock.json
+      COPY ${{ src_files }} ./
+      COPY ${{ package_json }} ./package.json
+      COPY ${{ package_json_lock }} ./package-lock.json
 
-      RUN ${{ parameter.build_command }}
+      RUN ${{ build_command }}
 
-      CMD ${{ parameter.start_command }}
-- name: image
+      CMD ${{ start_command }}
+- name: build
   module: docker/resource/local-image
-  argument:
+  arguments:
     dockerfile: ${{ dockerfile.filename }}
-    image: ${{ parameter.image }}
-    tag: ${{ parameter.tag }}
+    image: ${{ image }}
+    tag: ${{ tag }}

--- a/src/cli/cmd/apply.go
+++ b/src/cli/cmd/apply.go
@@ -49,9 +49,7 @@ var applyCmd = &cobra.Command{
 			}
 		}
 
-		evaluatedArg := module.Evaluate(argument, map[string]any{
-			"instances": states,
-		})
+		evaluatedArg := module.Evaluate(argument, states)
 
 		moduleExists := utils.Contains(modules, func(module module.Module) bool {
 			return module.Name == moduleName

--- a/src/cli/cmd/apply.go
+++ b/src/cli/cmd/apply.go
@@ -35,11 +35,7 @@ var applyCmd = &cobra.Command{
 
 		modules := module.ParseModules(codeBytes)
 
-		var argument map[string]any
-		err = yaml.Unmarshal([]byte(argumentString), &argument)
-		if err != nil {
-			panic(err)
-		}
+		arguments := map[string]any{}
 
 		states := map[string]any{}
 		for address, doc := range instances.Document() {
@@ -49,7 +45,14 @@ var applyCmd = &cobra.Command{
 			}
 		}
 
-		evaluatedArg := module.Evaluate(argument, states)
+		for k, yamlString := range argumentString {
+			var v any
+			err = yaml.Unmarshal([]byte(yamlString), &v)
+			if err != nil {
+				panic(err)
+			}
+			arguments[k] = module.Evaluate(v, states)
+		}
 
 		moduleExists := utils.Contains(modules, func(module module.Module) bool {
 			return module.Name == moduleName
@@ -62,13 +65,13 @@ var applyCmd = &cobra.Command{
 			return module.Name == moduleName
 		})
 
-		module.Apply(instanceName, evaluatedArg, &instances, modules)
+		module.Apply(instanceName, arguments, &instances, modules)
 	},
 }
 
-var argumentString = ""
+var argumentString map[string]string
 
 func init() {
 	rootCmd.AddCommand(applyCmd)
-	applyCmd.Flags().StringVarP(&argumentString, "argument", "a", "{}", "Argument")
+	applyCmd.Flags().StringToStringVarP(&argumentString, "argument", "a", map[string]string{}, "Argument")
 }

--- a/src/cli/cmd/destroy.go
+++ b/src/cli/cmd/destroy.go
@@ -20,11 +20,12 @@ var destroyCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		instanceName := args[0]
-		instances := repository.LoadDocumentRepository()
-		doc := instances.Find(instanceName)
-		instance := module.NewInstanceFromDocument(doc)
-		instance.Destroy(instanceName, &instances)
+		for _, instanceName := range args {
+			instances := repository.LoadDocumentRepository()
+			doc := instances.Find(instanceName)
+			instance := module.NewInstanceFromDocument(doc)
+			instance.Destroy(instanceName, &instances)
+		}
 	},
 }
 

--- a/src/cli/core/evaluator/lexer.go
+++ b/src/cli/core/evaluator/lexer.go
@@ -23,7 +23,7 @@ func NewLexer(reader io.Reader) *Lexer {
 		simplexer.NewRegexpTokenType(STRING, `"([^"]*)"`),
 		simplexer.NewRegexpTokenType(BOOLEAN, `true|false`),
 		simplexer.NewRegexpTokenType(NULL, `null`),
-		simplexer.NewRegexpTokenType(IDENTIFIER, `[a-zA-Z0-9_-]+`),
+		simplexer.NewRegexpTokenType(IDENTIFIER, `\$?[a-zA-Z0-9_-]+`),
 		simplexer.NewRegexpTokenType(DOT, `\.`),
 		simplexer.NewRegexpTokenType(COMMA, `,`),
 		simplexer.NewRegexpTokenType(COLON, `:`),

--- a/src/cli/core/module/instance.go
+++ b/src/cli/core/module/instance.go
@@ -78,13 +78,12 @@ func NewInstanceFromDocument(document any) Instance {
 func (instance moduleInstance) ToState(instances repository.DocumentRepository) any {
 	state := map[string]any{
 		"parameter": instance.Argument,
-		"modules":   map[string]any{},
 	}
 	for _, address := range instance.Instances {
 		childAbsAddr := instance.Address + "." + address
 		doc := instances.Find(childAbsAddr)
 		child := NewInstanceFromDocument(doc)
-		state["modules"].(map[string]any)[address] = child.ToState(instances)
+		state[address] = child.ToState(instances)
 	}
 	return state
 }

--- a/src/cli/core/module/instance.go
+++ b/src/cli/core/module/instance.go
@@ -16,11 +16,11 @@ type Instance interface {
 }
 
 type moduleInstance struct {
-	Type      string   `yaml:"type"`
-	Module    Module   `yaml:"module"`
-	Argument  any      `yaml:"argument"`
-	Address   string   `yaml:"address"`
-	Instances []string `yaml:"instances"`
+	Type      string         `yaml:"type"`
+	Module    Module         `yaml:"module"`
+	Arguments map[string]any `yaml:"argument"`
+	Address   string         `yaml:"address"`
+	Instances []string       `yaml:"instances"`
 }
 
 type pluginInstance struct {
@@ -31,12 +31,12 @@ type pluginInstance struct {
 	Output         any    `yaml:"output"`
 }
 
-func NewModuleInstance(module Module, address string, argument any) moduleInstance {
+func NewModuleInstance(module Module, address string, arguments map[string]any) moduleInstance {
 	return moduleInstance{
 		Type:      "module",
 		Module:    module,
 		Address:   address,
-		Argument:  argument,
+		Arguments: arguments,
 		Instances: []string{},
 	}
 }
@@ -76,9 +76,7 @@ func NewInstanceFromDocument(document any) Instance {
 }
 
 func (instance moduleInstance) ToState(instances repository.DocumentRepository) any {
-	state := map[string]any{
-		"parameter": instance.Argument,
-	}
+	state := instance.Arguments
 	for _, address := range instance.Instances {
 		childAbsAddr := instance.Address + "." + address
 		doc := instances.Find(childAbsAddr)

--- a/src/cli/core/module/module.go
+++ b/src/cli/core/module/module.go
@@ -89,7 +89,7 @@ func (module Module) Apply(
 			"address":           childAbsAddr,
 			"custom_state_path": customStatePath,
 		}
-		data["env"] = utils.GetEnvMap()
+		data["$env"] = utils.GetEnvMap()
 		if moduleCall.HasReferences("^self.custom_state_path$") {
 			err := os.MkdirAll(customStatePath, 0755)
 			if err != nil {

--- a/src/cli/core/module/module_test.go
+++ b/src/cli/core/module/module_test.go
@@ -20,9 +20,14 @@ modules:
     - bar
   module: resource/baz
   argument:
-    a: ${{ modules.baz }}
+    a: ${{ baz }}
     b: abc
 - name: bar
+  module: resource/qux
+  argument:
+    a: 123
+    b: abc
+- name: baz
   module: resource/qux
   argument:
     a: 123
@@ -32,7 +37,7 @@ modules:
 	assert.Len(t, modules, 1)
 	module := modules[0]
 	assert.Equal(t, "foo", module.Name)
-	assert.Equal(t, []string{"bar", "baz"}, module.FindModuleCall("foo").Dependency())
+	assert.Equal(t, []string{"bar", "baz"}, module.FindModuleCall("foo").Dependency(module.ModuleNames()))
 }
 
 func TestTopologicalSortedModuleCalls(t *testing.T) {
@@ -51,7 +56,7 @@ modules:
 - name: bar
   module: resource/a
   argument:
-    a: ${{ modules.baz }}
+    a: ${{ baz }}
 - name: baz
   module: resource/a
 `


### PR DESCRIPTION
Changed the expression PATH so that it can be expressed in a shorter form. 
The `modules` in the path is no longer needed.

```yaml
old: ${{ modules.foo.modules.bar }}
new: ${{ foo.bar }}
```

The `parameter` in the path is no longer needed.

```yaml
old: ${{ parmeter.foo.modules.bar }}
new: ${{ foo.bar}}
```

The `instances` in the path is no longer needed.

```yaml
old: ${{ instances.foo.bar }}
new: ${{ foo.bar }}
```

Meta variables such as `env` and `self` now need `$`.

```yaml
old: ${{ env.FOO }}
new: ${{ $env.FOO }}
```

```yaml
old: ${{ self.FOO }}
new: ${{ $self.FOO }}
```

Parameters can now take more than one. 

```yaml
# old
parameter:
  type: object
  default: { image: sample-api, tag: latest }
  properties:
      image: { type: string, default: sample-api }
      tag: { type: string, default: latest }

# new
parameters:
- name: image
  schema: { type: string, default: sample-api }
- name: tag
  schema: { type: string, default: latest }
```

This makes calling apply a little easier.

```bash
# old
$ dacrane apply aks dev -a '
env: dev
base: ${{ base }}
api: ${{ api-v1 }}
'

# new
$ dacrane apply aks dev \
  -a env=dev \
  -a base='${{ base }}' \
  -a api='${{ api-v1 }}'
```
